### PR TITLE
Disable quick pulldown by default

### DIFF
--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -24,7 +24,7 @@
         android:title="@string/status_bar_quick_qs_pulldown_title"
         android:entries="@array/status_bar_quick_qs_pulldown_entries"
         android:entryValues="@array/status_bar_quick_qs_pulldown_values"
-        android:defaultValue="1" />
+        android:defaultValue="0" />
 
     <cyanogenmod.preference.CMSystemSettingSwitchPreference
         android:key="status_bar_brightness_control"


### PR DESCRIPTION
With Android N this feature became less relevant since a subset of
the toggles is available without fully expanding the notification
panel. This gives better access to the notifications with almost no
functionality loss.

Change-Id: Idb66472b77e60f4ae753c5dd00f6588566cc3c63