### PR TITLE
Update style to match the one of Settings

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -18,7 +18,7 @@
     <attr name="side_margin" format="reference|dimension" />
     <attr name="wifi_signal_color" format="reference" />
 
-    <style name="PreferenceTheme" parent="@android:style/Theme.DeviceDefault.Settings">
+    <style name="PreferenceTheme" parent="@style/PreferenceThemeOverlay.v14.Material">
         <item name="preferenceStyle">@style/Preference</item>
         <item name="editTextPreferenceStyle">@style/EditTextPreference</item>
         <item name="dropdownPreferenceStyle">@style/Preference.DropDown.Material</item>


### PR DESCRIPTION
Use the same base theme used for Settings so that our preference
tiles look like the default ones (e.g. add ripple effect).

Change-Id: I27a5569535d8d614a0c0d26dd5b9fcd12f2af1e4