### PR TITLE
Fix reorientation of volume buttons on portrait tablets

### DIFF
--- a/src/org/cyanogenmod/cmparts/input/ButtonSettings.java
+++ b/src/org/cyanogenmod/cmparts/input/ButtonSettings.java
@@ -33,6 +33,8 @@ import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.PreferenceScreen;
 import android.util.Log;
+import android.view.Display;
+import android.view.DisplayInfo;
 import android.view.IWindowManager;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -706,6 +708,17 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
         if (preference == mSwapVolumeButtons) {
             int value = mSwapVolumeButtons.isChecked()
                     ? (ScreenType.isTablet(getActivity()) ? 2 : 1) : 0;
+            if (value == 2) {
+                Display defaultDisplay = getActivity().getWindowManager().getDefaultDisplay();
+
+                DisplayInfo displayInfo = new DisplayInfo();
+                defaultDisplay.getDisplayInfo(displayInfo);
+
+                // Not all tablets are landscape
+                if (displayInfo.getNaturalWidth() < displayInfo.getNaturalHeight()) {
+                    value = 1;
+                }
+            }
             CMSettings.System.putInt(getActivity().getContentResolver(),
                     CMSettings.System.SWAP_VOLUME_KEYS_ON_ROTATION, value);
         } else if (preference == mDisableNavigationKeys) {


### PR DESCRIPTION
* Mode '2' is supposed to be used for landscape devices,
  use mode '1' if the device's width is lower than height.

Change-Id: Id2752517fb74a1513219c878b269f0919811dcf1